### PR TITLE
Add Playwright test for Client Work page validation

### DIFF
--- a/tests/client-work-validation.spec.ts
+++ b/tests/client-work-validation.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect, chromium } from '@playwright/test';
+
+test('Verify Client Work page is accessible', async () => {
+  // Launch the Chrome browser
+  const browser = await chromium.launch({ headless: false }); // Set headless to false for visual debugging
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  try {
+    // Navigate to website
+    console.log('Navigating to https://www.epam.com/');
+    await page.goto('https://www.epam.com/');
+    
+    // Select "Services" from the header menu
+    console.log('Clicking on "Services" in the header menu');
+    await page.click('text=Services');
+    
+    // Click "Explore Our Client Work" link
+    console.log('Clicking on "Explore Our Client Work" link');
+    await page.click('text=Explore Our Client Work');
+    
+    // Verify the "Client Work" text is visible
+    console.log('Verifying "Client Work" text is visible');
+    const clientWorkText = await page.locator('text=Client Work');
+    await expect(clientWorkText).toBeVisible();
+    
+    console.log('Test executed successfully!');
+  } catch (error) {
+    console.error('Test execution failed:', error);
+    throw error; // Rethrow for further logging
+  } finally {
+    // Close browser
+    await browser.close();
+  }
+});


### PR DESCRIPTION
This pull request adds a Playwright test script for validating the "Client Work" page on https://www.epam.com/. 

The test script performs the following steps:
1. Navigates to https://www.epam.com/
2. Navigates to the Services page
3. Clicks on the "Explore Our Client Work" link
4. Verifies that the "Client Work" text is visible on the page

The test has been executed successfully in a Chrome browser.

Changes:
- Added TypeScript script for Playwright test in `tests/client-work-validation.spec.ts`

To run the test:
1. Ensure you have Playwright installed
2. Run `npx playwright test tests/client-work-validation.spec.ts`

Note: The test uses non-headless mode for visual debugging. For CI/CD pipelines, you may want to switch to headless mode.